### PR TITLE
fix null check used on null onChanged function

### DIFF
--- a/lib/src/location_picker.dart
+++ b/lib/src/location_picker.dart
@@ -233,7 +233,7 @@ class FlutterLocationPicker extends StatefulWidget {
   const FlutterLocationPicker({
     super.key,
     required this.onPicked,
-    this.onChanged,
+    required this.onChanged,
     this.selectedLocationButtonTextstyle = const TextStyle(fontSize: 20),
     this.onError,
     this.initPosition,


### PR DESCRIPTION
fix the error null check used on null value when onChanged is not declared when using the plugin.